### PR TITLE
Feat: 커스텀 Authenticaiton 적용

### DIFF
--- a/src/main/java/com/catcher/config/JwtFilter.java
+++ b/src/main/java/com/catcher/config/JwtFilter.java
@@ -1,23 +1,20 @@
 package com.catcher.config;
 
 import com.catcher.common.exception.BaseException;
-import com.catcher.utils.HttpServletUtils;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.apache.http.HttpHeaders;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Optional;
 
-import static com.catcher.common.BaseResponseStatus.*;
-import static com.catcher.utils.HttpServletUtils.*;
-import static org.apache.http.HttpHeaders.*;
+import static com.catcher.common.BaseResponseStatus.REDIS_ERROR;
+import static com.catcher.utils.HttpServletUtils.getHeader;
+import static org.apache.http.HttpHeaders.AUTHORIZATION;
 
 /**
  * 헤더(Authorization)에 있는 토큰을 꺼내 이상이 없는 경우 SecurityContext에 저장

--- a/src/main/java/com/catcher/core/dto/RefreshTokenDto.java
+++ b/src/main/java/com/catcher/core/dto/RefreshTokenDto.java
@@ -1,6 +1,5 @@
 package com.catcher.core.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 

--- a/src/main/java/com/catcher/core/service/AuthService.java
+++ b/src/main/java/com/catcher/core/service/AuthService.java
@@ -1,6 +1,5 @@
 package com.catcher.core.service;
 
-
 import com.catcher.core.dto.TokenDto;
 
 public interface AuthService {

--- a/src/main/java/com/catcher/infrastructure/oauth/handler/NaverOAuthHandler.java
+++ b/src/main/java/com/catcher/infrastructure/oauth/handler/NaverOAuthHandler.java
@@ -1,6 +1,5 @@
 package com.catcher.infrastructure.oauth.handler;
 
-
 import com.catcher.infrastructure.oauth.properties.OAuthProperties;
 import com.catcher.resource.external.OAuthFeignController;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/src/main/java/com/catcher/infrastructure/oauth/user/OAuthUserInfoFactory.java
+++ b/src/main/java/com/catcher/infrastructure/oauth/user/OAuthUserInfoFactory.java
@@ -1,6 +1,5 @@
 package com.catcher.infrastructure.oauth.user;
 
-import com.catcher.common.BaseResponseStatus;
 import com.catcher.common.exception.BaseException;
 import com.catcher.core.domain.entity.enums.UserProvider;
 import lombok.AccessLevel;

--- a/src/main/java/com/catcher/resource/UserController.java
+++ b/src/main/java/com/catcher/resource/UserController.java
@@ -35,6 +35,6 @@ public class UserController {
     //TODO: 삭제예정
     @PostMapping("/test")
     public void test(@CurrentUser User user) {
-        System.out.println("user = " + user);
+        log.info("user = {}", user);
     }
 }

--- a/src/main/java/com/catcher/resource/UserController.java
+++ b/src/main/java/com/catcher/resource/UserController.java
@@ -1,10 +1,12 @@
 package com.catcher.resource;
 
 import com.catcher.common.response.BaseResponse;
+import com.catcher.core.domain.entity.User;
 import com.catcher.core.dto.user.UserCreateRequest;
 import com.catcher.core.service.UserService;
 import com.catcher.core.dto.TokenDto;
 import com.catcher.core.dto.user.UserLoginRequest;
+import com.catcher.security.annotation.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -28,5 +30,11 @@ public class UserController {
     @PostMapping("/login")
     public BaseResponse<TokenDto> login(@Valid @RequestBody UserLoginRequest userLoginReqDto) {
         return new BaseResponse<>(userService.login(userLoginReqDto));
+    }
+
+    //TODO: 삭제예정
+    @PostMapping("/test")
+    public void test(@CurrentUser User user) {
+        System.out.println("user = " + user);
     }
 }

--- a/src/main/java/com/catcher/security/AuthenticationProxy.java
+++ b/src/main/java/com/catcher/security/AuthenticationProxy.java
@@ -18,9 +18,7 @@ public class AuthenticationProxy implements AuthenticationManager {
         CatcherUser catcherUser = (CatcherUser) userDetailsService.loadUserByUsername((String) authentication.getPrincipal());
 
         String rawPassword =(String) authentication.getCredentials();
-        String encodedPassword = catcherUser.getPassword();
-        System.out.println(passwordEncoder.matches(rawPassword, encodedPassword));
-        System.out.println(passwordEncoder.matches(encodedPassword,rawPassword));
+
         if(!passwordEncoder.matches(rawPassword, catcherUser.getPassword())) {
             throw new BadCredentialsException("자격 증명에 실패하였습니다.");
         }

--- a/src/main/java/com/catcher/security/AuthenticationProxy.java
+++ b/src/main/java/com/catcher/security/AuthenticationProxy.java
@@ -1,0 +1,30 @@
+package com.catcher.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@RequiredArgsConstructor
+public class AuthenticationProxy implements AuthenticationManager {
+    private final UserDetailsService userDetailsService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public CatcherUser authenticate(Authentication authentication) throws AuthenticationException {
+        CatcherUser catcherUser = (CatcherUser) userDetailsService.loadUserByUsername((String) authentication.getPrincipal());
+
+        String rawPassword =(String) authentication.getCredentials();
+        String encodedPassword = catcherUser.getPassword();
+        System.out.println(passwordEncoder.matches(rawPassword, encodedPassword));
+        System.out.println(passwordEncoder.matches(encodedPassword,rawPassword));
+        if(!passwordEncoder.matches(rawPassword, catcherUser.getPassword())) {
+            throw new BadCredentialsException("자격 증명에 실패하였습니다.");
+        }
+
+        return catcherUser;
+    }
+}

--- a/src/main/java/com/catcher/security/CatcherUser.java
+++ b/src/main/java/com/catcher/security/CatcherUser.java
@@ -1,0 +1,58 @@
+package com.catcher.security;
+
+import com.catcher.core.domain.entity.User;
+import com.catcher.core.domain.entity.enums.UserRole;
+import lombok.Getter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+
+import static java.util.Collections.singleton;
+
+/**
+ * SecurityContext에 들어갈 Authentication 정보
+ */
+@Getter
+public class CatcherUser extends org.springframework.security.core.userdetails.User implements Authentication {
+    private User user;
+    public CatcherUser(User user) {
+        super(user.getUsername(), user.getPassword(), parseAuthority(user.getUserRole()));
+        this.user = user;
+    }
+
+    private static Collection<? extends GrantedAuthority> parseAuthority(UserRole userRole) {
+        return singleton(new SimpleGrantedAuthority(userRole.getValue()));
+    }
+
+    @Override
+    public Object getCredentials() {
+        return this.user;
+    }
+
+    @Override
+    public Object getDetails() {
+        return user.getUsername();
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return user.getPassword();
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return true;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+
+    }
+
+    @Override
+    public String getName() {
+        return user.getUsername();
+    }
+}

--- a/src/main/java/com/catcher/security/SecurityConfig.java
+++ b/src/main/java/com/catcher/security/SecurityConfig.java
@@ -10,7 +10,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -18,6 +17,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
 
 @Configuration
 @EnableWebSecurity
@@ -39,9 +39,9 @@ public class SecurityConfig {
 
     @Bean
     public AuthenticationManager authenticationManager(
-            AuthenticationConfiguration authenticationConfiguration
+            UserDetailServiceImpl userDetailService, PasswordEncoder passwordEncoder
     ) throws Exception {
-        return authenticationConfiguration.getAuthenticationManager();
+        return new AuthenticationProxy(userDetailService, passwordEncoder);
     }
 
     @Bean

--- a/src/main/java/com/catcher/security/UserDetailServiceImpl.java
+++ b/src/main/java/com/catcher/security/UserDetailServiceImpl.java
@@ -1,22 +1,13 @@
 package com.catcher.security;
 
 import com.catcher.common.exception.BaseException;
-import com.catcher.core.domain.entity.User;
-import com.catcher.core.domain.entity.enums.UserRole;
 import com.catcher.core.database.UserRepository;
+import com.catcher.core.domain.entity.User;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collection;
-import java.util.Set;
 
 import static com.catcher.common.BaseResponseStatus.INVALID_USER_NAME;
 
@@ -28,23 +19,14 @@ public class UserDetailServiceImpl implements UserDetailsService {
 
     @Override
     @Transactional(readOnly = true)
-    public UserDetails loadUserByUsername(String username) throws BaseException {
+    public CatcherUser loadUserByUsername(String username) throws BaseException {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> {
                     log.error(INVALID_USER_NAME.getMessage());
                     return new BaseException(INVALID_USER_NAME);
                 });
 
-        Collection<? extends GrantedAuthority> authorities = createAuthorities(user.getUserRole());
-        return new org
-                .springframework
-                .security
-                .core
-                .userdetails
-                .User(user.getUsername(), user.getPassword(), authorities);
-    }
 
-    private Collection<? extends GrantedAuthority> createAuthorities(UserRole userRole) {
-        return Set.of(new SimpleGrantedAuthority(userRole.getValue()));
+        return new CatcherUser(user);
     }
 }

--- a/src/main/java/com/catcher/security/annotation/CurrentUser.java
+++ b/src/main/java/com/catcher/security/annotation/CurrentUser.java
@@ -1,0 +1,14 @@
+package com.catcher.security.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : user")
+public @interface CurrentUser {
+}


### PR DESCRIPTION
OAuth로 회원가입한 유저들이 로그인을 할 경우를 방지하기 위한 Authentication 커스텀을 진행했습니다.

Spring Security Context는 CatcherUser로 저장됩니다.
CatcherUser클래스의 principal은 User 객체를 저장합니다.
추후, @AuthenticationPrincipal 어노테이션을 사용하여, User객체를 사용할 계획입니다.

<img width="666" alt="image" src="https://github.com/Project-Catcher/core-service/assets/108642272/d4384c12-c7c2-43bb-b02b-106c1ec5993e">

UserDetailsService서비스는 위 사진과 같이 CatcherUser객체로 Security Context에 저장합니다.

---
추가로 @CurrentUser 어노테이션 추가하였습니다. 
밑에 예제에서 보는 것처럼 해당 어노테이션을 통해, 유저가 토큰을 통해 요청했다면, 필터내부에서 SecurityContext가 설정되고, SecurityContext 내부의 Principal을 가져올 수 있습니다.

<img width="680" alt="image" src="https://github.com/Project-Catcher/core-service/assets/108642272/ec74e7e2-90ac-4306-9b6e-0ad466d68878">

<img width="360" alt="image" src="https://github.com/Project-Catcher/core-service/assets/108642272/2ae9dd2e-b07d-4df2-810a-8733cc4bd3d0">

