### PR TITLE
update: 워크플로우 내 argocd app sync 커맨드로 대체

### DIFF
--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -96,9 +96,7 @@ jobs:
           git push -u origin main
 
       - name: Sync ArgoCD Application
-        uses: omegion/argocd-actions@v1
-        with:
-          address: "argocd.dev-alltimecatcher.com"
-          token: ${{ secrets.ARGOCD_TOKEN }}
-          action: sync
-          appName: "dev-app-core"
+        run: |
+          argocd app sync dev-app-core \
+          --server argocd.dev-alltimecatcher.com \
+          --auth-token ${{ secrets.ARGOCD_TOKEN }} --insecure


### PR DESCRIPTION
# argocd app sync 방법 변경
- AS-IS : "omegion/argocd-actions@v1" 이미지 사용
- TO-BE : argocd CLI 옵션 활용을 위해 argocd 커맨드로 변경