### PR TITLE
유저 엔티티 변경 및 수정

### DIFF
--- a/src/main/java/com/catcher/core/domain/entity/BaseTimeEntity.java
+++ b/src/main/java/com/catcher/core/domain/entity/BaseTimeEntity.java
@@ -3,11 +3,14 @@ package com.catcher.core.domain.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 @MappedSuperclass
 @Getter
 public class BaseTimeEntity {
+    public static ZoneId zoneId = ZoneId.of("Asia/Seoul");
+
     @Column(name = "created_at")
     private ZonedDateTime createdAt;
 
@@ -16,12 +19,12 @@ public class BaseTimeEntity {
 
     @PrePersist
     private void prePersist() {
-        this.createdAt = ZonedDateTime.now();
-        this.updatedAt = ZonedDateTime.now();
+        this.createdAt = ZonedDateTime.now(zoneId);
+        this.updatedAt = ZonedDateTime.now(zoneId);
     }
 
     @PreUpdate
     private void preUpdate() {
-        this.updatedAt = ZonedDateTime.now();
+        this.updatedAt = ZonedDateTime.now(zoneId);
     }
 }

--- a/src/main/java/com/catcher/core/domain/entity/User.java
+++ b/src/main/java/com/catcher/core/domain/entity/User.java
@@ -44,6 +44,8 @@ public class User extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private UserRole userRole;
 
+    private ZonedDateTime phoneAuthentication;
+
     @Column(nullable = false)
     private ZonedDateTime userAgeTerm; // 필수 약관
 

--- a/src/main/java/com/catcher/core/domain/entity/User.java
+++ b/src/main/java/com/catcher/core/domain/entity/User.java
@@ -3,10 +3,7 @@ package com.catcher.core.domain.entity;
 import com.catcher.core.domain.entity.enums.UserProvider;
 import com.catcher.core.domain.entity.enums.UserRole;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.ZonedDateTime;
 
@@ -15,6 +12,8 @@ import java.time.ZonedDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "users")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,7 +22,6 @@ public class User extends BaseTimeEntity {
     @Column(unique = true, nullable = false)
     private String username;
 
-    // TODO: encrypted maybe?
     @Column(nullable = false)
     private String password;
 
@@ -33,7 +31,6 @@ public class User extends BaseTimeEntity {
     @Column(unique = true, nullable = false)
     private String email;
 
-    // TODO : 첨부파일 외래키 참조해야 지
     private String profileImageUrl;
 
     private String introduceContent;
@@ -56,28 +53,9 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private ZonedDateTime userPrivacyTerm; // 필수 약관
 
-    @Column(nullable = false)
-    private ZonedDateTime userLocationTerm; // 필수 약관
+    private ZonedDateTime emailMarketingTerm; // 이메일 선택약관
 
-    private ZonedDateTime userMarketingTerm; // 선택 약관
+    private ZonedDateTime phoneMarketingTerm; // 핸드폰 선택약관
 
     private ZonedDateTime deletedAt;
-
-    @Builder
-    public User(String username, String password,  String email, String profileImageUrl, String phone, String nickname, UserProvider userProvider, UserRole role, ZonedDateTime userAgeTerm, ZonedDateTime userServiceTerm, ZonedDateTime userPrivacyTerm, ZonedDateTime userLocationTerm, String introduceContent, ZonedDateTime userMarketingTerm){
-        this.username = username;
-        this.password = password;
-        this.email = email;
-        this.profileImageUrl = profileImageUrl;
-        this.userProvider = userProvider;
-        this.phone = phone;
-        this.nickname = nickname;
-        this.userRole = role;
-        this.userAgeTerm = userAgeTerm;
-        this.userServiceTerm = userServiceTerm;
-        this.userPrivacyTerm = userPrivacyTerm;
-        this.userLocationTerm = userLocationTerm;
-        this.introduceContent = introduceContent;
-        this.userMarketingTerm = userMarketingTerm;
-    }
 }

--- a/src/main/java/com/catcher/core/dto/oauth/OAuthCreateRequest.java
+++ b/src/main/java/com/catcher/core/dto/oauth/OAuthCreateRequest.java
@@ -26,10 +26,6 @@ public class OAuthCreateRequest {
     @DateTimeFormat(pattern = "yyyy-MM-ddTHH:mm:ssZZ")
     private ZonedDateTime privacyTerm;
 
-    @NotNull(message = "필수 약관 위치 정보 이용 동의해주세요.")
-    @DateTimeFormat(pattern = "yyyy-MM-ddTHH:mm:ssZZ")
-    private ZonedDateTime locationTerm;
-
     @NotNull(message = "액세스 토큰이 없습니다.")
     private String accessToken;
 

--- a/src/main/java/com/catcher/core/dto/user/UserCreateRequest.java
+++ b/src/main/java/com/catcher/core/dto/user/UserCreateRequest.java
@@ -1,16 +1,15 @@
 package com.catcher.core.dto.user;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.ZonedDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class UserCreateRequest {
     @NotNull(message = "아이디를 입력하세요.")
     private String username;
@@ -39,25 +38,7 @@ public class UserCreateRequest {
     @DateTimeFormat(pattern = "yyyy-MM-ddTHH:mm:ssZZ")
     private ZonedDateTime privacyTerm;
 
-    @NotNull(message = "필수 약관 위치 정보 이용 동의해주세요.")
-    @DateTimeFormat(pattern = "yyyy-MM-ddTHH:mm:ssZZ")
-    private ZonedDateTime locationTerm;
-
     @DateTimeFormat(pattern = "yyyy-MM-ddTHH:mm:ssZZ")
     private ZonedDateTime marketingTerm;
-
-    @Builder
-    public UserCreateRequest(String username, String password, String email, String phone, String nickname, ZonedDateTime ageTerm, ZonedDateTime serviceTerm, ZonedDateTime privacyTerm, ZonedDateTime locationTerm, ZonedDateTime marketingTerm){
-        this.username = username;
-        this.password = password;
-        this.email = email;
-        this.phone = phone;
-        this.nickname = nickname;
-        this.ageTerm = ageTerm;
-        this.serviceTerm = serviceTerm;
-        this.privacyTerm = privacyTerm;
-        this.locationTerm = locationTerm;
-        this.marketingTerm = marketingTerm;
-    }
 }
 

--- a/src/main/java/com/catcher/core/service/OAuthService.java
+++ b/src/main/java/com/catcher/core/service/OAuthService.java
@@ -12,8 +12,8 @@ import com.catcher.core.dto.TokenDto;
 import com.catcher.core.dto.oauth.OAuthCreateRequest;
 import com.catcher.core.dto.oauth.OAuthHistoryResponse;
 import com.catcher.infrastructure.oauth.OAuthTokenResponse;
-import com.catcher.infrastructure.oauth.handler.OAuthHandlerFactory;
 import com.catcher.infrastructure.oauth.handler.OAuthHandler;
+import com.catcher.infrastructure.oauth.handler.OAuthHandlerFactory;
 import com.catcher.infrastructure.oauth.properties.OAuthProperties;
 import com.catcher.infrastructure.oauth.user.OAuthUserInfo;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +33,6 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.catcher.common.BaseResponseStatus.*;
-import static com.catcher.core.domain.entity.enums.UserRole.USER;
 import static com.catcher.utils.JwtUtils.REFRESH_TOKEN_EXPIRATION_MILLIS;
 
 @Service
@@ -113,14 +112,13 @@ public class OAuthService {
                 .password(passwordEncoder.encode("NO-PASS"))
                 .phone(oAuthCreateRequest.getPhone())
                 .email(oAuthUserInfo.getEmail())
-                .nickname(oAuthUserInfo.getProvider().name() + "_" + oAuthUserInfo.getId())
+                .nickname(oAuthCreateRequest.getNickname())
                 .userProvider(oAuthUserInfo.getProvider())
-                .role(USER)
                 .userAgeTerm(oAuthCreateRequest.getAgeTerm())
                 .userServiceTerm(oAuthCreateRequest.getServiceTerm())
                 .userPrivacyTerm(oAuthCreateRequest.getPrivacyTerm())
-                .userLocationTerm(oAuthCreateRequest.getLocationTerm())
-                .userMarketingTerm(oAuthCreateRequest.getMarketingTerm())
+                .emailMarketingTerm(oAuthCreateRequest.getMarketingTerm())
+                .phoneMarketingTerm(oAuthCreateRequest.getMarketingTerm())
                 .build();
     }
 

--- a/src/main/java/com/catcher/core/service/OAuthService.java
+++ b/src/main/java/com/catcher/core/service/OAuthService.java
@@ -114,6 +114,7 @@ public class OAuthService {
                 .email(oAuthUserInfo.getEmail())
                 .nickname(oAuthCreateRequest.getNickname())
                 .userProvider(oAuthUserInfo.getProvider())
+                .phoneAuthentication(null)
                 .userAgeTerm(oAuthCreateRequest.getAgeTerm())
                 .userServiceTerm(oAuthCreateRequest.getServiceTerm())
                 .userPrivacyTerm(oAuthCreateRequest.getPrivacyTerm())

--- a/src/main/java/com/catcher/core/service/UserService.java
+++ b/src/main/java/com/catcher/core/service/UserService.java
@@ -4,11 +4,11 @@ import com.catcher.common.BaseResponseStatus;
 import com.catcher.common.exception.BaseException;
 import com.catcher.config.JwtTokenProvider;
 import com.catcher.core.database.DBManager;
+import com.catcher.core.database.UserRepository;
+import com.catcher.core.domain.entity.User;
 import com.catcher.core.dto.TokenDto;
 import com.catcher.core.dto.user.UserCreateRequest;
 import com.catcher.core.dto.user.UserLoginRequest;
-import com.catcher.core.domain.entity.User;
-import com.catcher.core.database.UserRepository;
 import com.catcher.security.CatcherUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,12 +20,14 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static com.catcher.common.BaseResponseStatus.*;
-import static com.catcher.core.domain.entity.enums.UserProvider.*;
-import static com.catcher.core.domain.entity.enums.UserRole.*;
-import static com.catcher.utils.JwtUtils.*;
+import static com.catcher.core.domain.entity.BaseTimeEntity.zoneId;
+import static com.catcher.core.domain.entity.enums.UserProvider.CATCHER;
+import static com.catcher.core.domain.entity.enums.UserRole.USER;
+import static com.catcher.utils.JwtUtils.REFRESH_TOKEN_EXPIRATION_MILLIS;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -94,6 +96,7 @@ public class UserService {
                 .nickname(userCreateRequest.getNickname())
                 .userProvider(CATCHER)
                 .userRole(USER)
+                .phoneAuthentication(ZonedDateTime.now(zoneId))
                 .userAgeTerm(userCreateRequest.getAgeTerm())
                 .userServiceTerm(userCreateRequest.getServiceTerm())
                 .userPrivacyTerm(userCreateRequest.getPrivacyTerm())

--- a/src/main/java/com/catcher/core/service/UserService.java
+++ b/src/main/java/com/catcher/core/service/UserService.java
@@ -87,18 +87,18 @@ public class UserService {
 
     private User createUser(UserCreateRequest userCreateRequest) {
         return User.builder()
-                .password(passwordEncoder.encode(userCreateRequest.getPassword()))
                 .username(userCreateRequest.getUsername())
-                .email(userCreateRequest.getEmail())
+                .password(passwordEncoder.encode(userCreateRequest.getPassword()))
                 .phone(userCreateRequest.getPhone())
+                .email(userCreateRequest.getEmail())
                 .nickname(userCreateRequest.getNickname())
+                .userProvider(CATCHER)
+                .userRole(USER)
                 .userAgeTerm(userCreateRequest.getAgeTerm())
                 .userServiceTerm(userCreateRequest.getServiceTerm())
                 .userPrivacyTerm(userCreateRequest.getPrivacyTerm())
-                .userLocationTerm(userCreateRequest.getLocationTerm())
-                .userMarketingTerm(userCreateRequest.getMarketingTerm())
-                .role(USER)
-                .userProvider(CATCHER)
+                .emailMarketingTerm(userCreateRequest.getMarketingTerm())
+                .phoneMarketingTerm(userCreateRequest.getMarketingTerm())
                 .build();
     }
 

--- a/src/test/java/com/catcher/config/JwtFilterTest.java
+++ b/src/test/java/com/catcher/config/JwtFilterTest.java
@@ -32,7 +32,6 @@ import java.util.UUID;
 import static com.catcher.core.domain.entity.enums.UserProvider.CATCHER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 @ActiveProfiles("test")
 @SpringBootTest(classes = {AppApplication.class, EmbeddedRedisConfiguration.class})
@@ -125,12 +124,12 @@ class JwtFilterTest {
                 .introduceContent(null)
                 .nickname(createRandomUUID())
                 .userProvider(CATCHER)
-                .role(UserRole.USER)
+                .userRole(UserRole.USER)
                 .userAgeTerm(ZonedDateTime.now())
                 .userServiceTerm(ZonedDateTime.now())
                 .userPrivacyTerm(ZonedDateTime.now())
-                .userLocationTerm(ZonedDateTime.now())
-                .userMarketingTerm(ZonedDateTime.now())
+                .emailMarketingTerm(ZonedDateTime.now())
+                .phoneMarketingTerm(ZonedDateTime.now())
                 .build();
 
         userRepository.save(user);

--- a/src/test/java/com/catcher/config/JwtTokenProviderTest.java
+++ b/src/test/java/com/catcher/config/JwtTokenProviderTest.java
@@ -1,7 +1,6 @@
 package com.catcher.config;
 
 import com.catcher.app.AppApplication;
-import com.catcher.common.exception.BaseException;
 import com.catcher.core.database.UserRepository;
 import com.catcher.core.domain.entity.User;
 import com.catcher.core.domain.entity.enums.UserRole;
@@ -24,7 +23,6 @@ import java.util.UUID;
 import static com.catcher.core.domain.entity.enums.UserProvider.CATCHER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 @ActiveProfiles("test")
 @SpringBootTest(classes = {AppApplication.class, EmbeddedRedisConfiguration.class})
@@ -119,12 +117,12 @@ class JwtTokenProviderTest {
                 .introduceContent(null)
                 .nickname(createRandomUUID())
                 .userProvider(CATCHER)
-                .role(UserRole.USER)
+                .userRole(UserRole.USER)
                 .userAgeTerm(ZonedDateTime.now())
                 .userServiceTerm(ZonedDateTime.now())
                 .userPrivacyTerm(ZonedDateTime.now())
-                .userLocationTerm(ZonedDateTime.now())
-                .userMarketingTerm(ZonedDateTime.now())
+                .emailMarketingTerm(ZonedDateTime.now())
+                .phoneMarketingTerm(ZonedDateTime.now())
                 .build();
 
         userRepository.save(user);

--- a/src/test/java/com/catcher/core/database/UserRepositoryTest.java
+++ b/src/test/java/com/catcher/core/database/UserRepositoryTest.java
@@ -193,12 +193,12 @@ class UserRepositoryTest {
                 .introduceContent(null)
                 .nickname(createRandomUUID())
                 .userProvider(CATCHER)
-                .role(UserRole.USER)
+                .userRole(UserRole.USER)
                 .userAgeTerm(ZonedDateTime.now())
                 .userServiceTerm(ZonedDateTime.now())
                 .userPrivacyTerm(ZonedDateTime.now())
-                .userLocationTerm(ZonedDateTime.now())
-                .userMarketingTerm(ZonedDateTime.now())
+                .emailMarketingTerm(ZonedDateTime.now())
+                .phoneMarketingTerm(ZonedDateTime.now())
                 .build();
 
         userRepository.save(user);

--- a/src/test/java/com/catcher/core/service/AuthServiceTest.java
+++ b/src/test/java/com/catcher/core/service/AuthServiceTest.java
@@ -82,7 +82,6 @@ class AuthServiceTest {
         return UserCreateRequest.builder()
                 .nickname(nickname)
                 .ageTerm(ZonedDateTime.now())
-                .locationTerm(ZonedDateTime.now())
                 .serviceTerm(ZonedDateTime.now())
                 .marketingTerm(ZonedDateTime.now())
                 .privacyTerm(ZonedDateTime.now())

--- a/src/test/java/com/catcher/core/service/UserServiceTest.java
+++ b/src/test/java/com/catcher/core/service/UserServiceTest.java
@@ -250,6 +250,20 @@ class UserServiceTest {
                 .isInstanceOf(BaseException.class);
     }
 
+    @DisplayName("캐쳐 회원가입 시, 핸드폰 인증이 완료되어있어야 한다.")
+    @Test
+    void sign_up_need_phone_authentication() {
+        //given
+        UserCreateRequest userCreateRequest = userCreateRequest(createRandomUUID(), createRandomUUID(), createRandomUUID(), createRandomUUID());
+        //when
+        userService.signUpUser(userCreateRequest);
+        flushAndClearPersistence();
+
+        //then
+        User user = userRepository.findByEmail(userCreateRequest.getEmail()).orElseThrow();
+        assertThat(user.getUserProvider()).isEqualTo(CATCHER);
+        assertThat(user.getPhoneAuthentication()).isNotNull();
+    }
 
     //region PRIVATE METHOD
     private UserLoginRequest userLoginRequest(String username,String password) {

--- a/src/test/java/com/catcher/core/service/UserServiceTest.java
+++ b/src/test/java/com/catcher/core/service/UserServiceTest.java
@@ -151,12 +151,12 @@ class UserServiceTest {
                 .introduceContent(null)
                 .nickname(createRandomUUID())
                 .userProvider(KAKAO)
-                .role(UserRole.USER)
+                .userRole(UserRole.USER)
                 .userAgeTerm(ZonedDateTime.now())
                 .userServiceTerm(ZonedDateTime.now())
                 .userPrivacyTerm(ZonedDateTime.now())
-                .userLocationTerm(ZonedDateTime.now())
-                .userMarketingTerm(ZonedDateTime.now())
+                .emailMarketingTerm(ZonedDateTime.now())
+                .phoneMarketingTerm(ZonedDateTime.now())
                 .build();
         userRepository.save(oAuthUser);
         flushAndClearPersistence();
@@ -184,12 +184,12 @@ class UserServiceTest {
                 .introduceContent(null)
                 .nickname(createRandomUUID())
                 .userProvider(NAVER)
-                .role(UserRole.USER)
+                .userRole(UserRole.USER)
                 .userAgeTerm(ZonedDateTime.now())
                 .userServiceTerm(ZonedDateTime.now())
                 .userPrivacyTerm(ZonedDateTime.now())
-                .userLocationTerm(ZonedDateTime.now())
-                .userMarketingTerm(ZonedDateTime.now())
+                .emailMarketingTerm(ZonedDateTime.now())
+                .phoneMarketingTerm(ZonedDateTime.now())
                 .build();
         userRepository.save(oAuthUser);
         flushAndClearPersistence();
@@ -260,7 +260,6 @@ class UserServiceTest {
         return UserCreateRequest.builder()
                 .nickname(nickname)
                 .ageTerm(ZonedDateTime.now())
-                .locationTerm(ZonedDateTime.now())
                 .serviceTerm(ZonedDateTime.now())
                 .marketingTerm(ZonedDateTime.now())
                 .privacyTerm(ZonedDateTime.now())
@@ -281,12 +280,12 @@ class UserServiceTest {
                 .introduceContent(null)
                 .nickname(nickname)
                 .userProvider(CATCHER)
-                .role(UserRole.USER)
+                .userRole(UserRole.USER)
                 .userAgeTerm(ZonedDateTime.now())
                 .userServiceTerm(ZonedDateTime.now())
                 .userPrivacyTerm(ZonedDateTime.now())
-                .userLocationTerm(ZonedDateTime.now())
-                .userMarketingTerm(ZonedDateTime.now())
+                .emailMarketingTerm(ZonedDateTime.now())
+                .phoneMarketingTerm(ZonedDateTime.now())
                 .build();
     }
 

--- a/src/test/java/com/catcher/resource/AuthControllerTest.java
+++ b/src/test/java/com/catcher/resource/AuthControllerTest.java
@@ -165,7 +165,6 @@ class AuthControllerTest {
         return UserCreateRequest.builder()
                 .nickname(createRandomUUID())
                 .ageTerm(ZonedDateTime.now())
-                .locationTerm(ZonedDateTime.now())
                 .serviceTerm(ZonedDateTime.now())
                 .marketingTerm(ZonedDateTime.now())
                 .privacyTerm(ZonedDateTime.now())

--- a/src/test/java/com/catcher/resource/UserControllerTest.java
+++ b/src/test/java/com/catcher/resource/UserControllerTest.java
@@ -337,7 +337,6 @@ class UserControllerTest {
         return UserCreateRequest.builder()
                 .nickname(nickname)
                 .ageTerm(ZonedDateTime.now())
-                .locationTerm(ZonedDateTime.now())
                 .serviceTerm(ZonedDateTime.now())
                 .marketingTerm(ZonedDateTime.now())
                 .privacyTerm(ZonedDateTime.now())
@@ -359,12 +358,12 @@ class UserControllerTest {
                 .introduceContent(null)
                 .nickname(createRandomUUID())
                 .userProvider(CATCHER)
-                .role(UserRole.USER)
+                .userRole(UserRole.USER)
                 .userAgeTerm(ZonedDateTime.now())
                 .userServiceTerm(ZonedDateTime.now())
                 .userPrivacyTerm(ZonedDateTime.now())
-                .userLocationTerm(ZonedDateTime.now())
-                .userMarketingTerm(ZonedDateTime.now())
+                .emailMarketingTerm(ZonedDateTime.now())
+                .phoneMarketingTerm(ZonedDateTime.now())
                 .build();
     }
 


### PR DESCRIPTION
1. 기존 마케팅 동의 -> 휴대폰, 이메일 동의 항목으로 분할되었습니다.
2. 지역 동의 -> 기획에 따라 삭제 되었습니다.

위 두가지 항목에 따라 엔티티 수정 및 테스트 코드 수정 리펙토링 진행했습니다.