### PR TITLE
Feat: 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/catcher/config/JwtFilter.java
+++ b/src/main/java/com/catcher/config/JwtFilter.java
@@ -1,10 +1,13 @@
 package com.catcher.config;
 
 import com.catcher.common.exception.BaseException;
+import com.catcher.core.database.DBManager;
+import com.catcher.utils.JwtUtils;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -21,12 +24,10 @@ import static org.apache.http.HttpHeaders.AUTHORIZATION;
  * Request 이전에 작동
  */
 
+@RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
-
-    public JwtFilter(JwtTokenProvider jwtTokenProvider) {
-        this.jwtTokenProvider = jwtTokenProvider;
-    }
+    private final DBManager dbManager;
 
     @Override
     protected void doFilterInternal(
@@ -34,11 +35,10 @@ public class JwtFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain
     ) throws ServletException, IOException {
-
-        String accessToken = getAccessToken(request);
-
         try {
-            if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
+            String accessToken = getAccessToken(request);
+
+            if (accessToken != null && jwtTokenProvider.validateToken(accessToken) && !isBlackList(accessToken)) {
                 Authentication auth = jwtTokenProvider.getAuthentication(accessToken);
                 SecurityContextHolder.getContext().setAuthentication(auth); // 정상 토큰이면 SecurityContext에 저장
             }
@@ -48,6 +48,11 @@ public class JwtFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private boolean isBlackList(String accessToken) {
+        String blackListToken = JwtUtils.generateBlackListToken(accessToken);
+        return dbManager.getValue(blackListToken).isPresent();
     }
 
     private String getAccessToken(HttpServletRequest request) {

--- a/src/main/java/com/catcher/config/JwtTokenProvider.java
+++ b/src/main/java/com/catcher/config/JwtTokenProvider.java
@@ -71,7 +71,6 @@ public class JwtTokenProvider {
     }
 
     public boolean validateToken(String token) {
-
         try {
             checkToken(token);
             Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);

--- a/src/main/java/com/catcher/core/service/AuthService.java
+++ b/src/main/java/com/catcher/core/service/AuthService.java
@@ -6,4 +6,6 @@ public interface AuthService {
     TokenDto reissueRefreshToken(String refreshToken);
 
     void discardRefreshToken(String refreshToken);
+
+    void discardAccessToken(String accessToken);
 }

--- a/src/main/java/com/catcher/core/service/UserService.java
+++ b/src/main/java/com/catcher/core/service/UserService.java
@@ -39,6 +39,7 @@ public class UserService {
     private final AuthenticationManager authenticationManager;
     private final PasswordEncoder passwordEncoder;
     private final DBManager dbManager;
+    private final AuthService authService;
 
     @Transactional
     public TokenDto signUpUser(UserCreateRequest userCreateRequest) {
@@ -56,6 +57,11 @@ public class UserService {
 
     public TokenDto login(UserLoginRequest userLoginReqDto) {
         return checkAuthenticationAndGetTokenDto(userLoginReqDto.getUsername(), userLoginReqDto.getPassword());
+    }
+
+    public void logout(String accessToken, String refreshToken) {
+        authService.discardAccessToken(accessToken);
+        authService.discardAccessToken(refreshToken);
     }
 
     private TokenDto checkAuthenticationAndGetTokenDto(String username, String password) {

--- a/src/main/java/com/catcher/core/service/UserService.java
+++ b/src/main/java/com/catcher/core/service/UserService.java
@@ -61,7 +61,7 @@ public class UserService {
 
     public void logout(String accessToken, String refreshToken) {
         authService.discardAccessToken(accessToken);
-        authService.discardAccessToken(refreshToken);
+        authService.discardRefreshToken(refreshToken);
     }
 
     private TokenDto checkAuthenticationAndGetTokenDto(String username, String password) {

--- a/src/main/java/com/catcher/infrastructure/adaptor/RefreshTokenAdaptor.java
+++ b/src/main/java/com/catcher/infrastructure/adaptor/RefreshTokenAdaptor.java
@@ -6,6 +6,7 @@ import com.catcher.core.database.DBManager;
 import com.catcher.core.dto.TokenDto;
 import com.catcher.core.service.AuthService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +15,7 @@ import java.util.Optional;
 import static com.catcher.common.BaseResponseStatus.NOT_EXIST_REFRESH_JWT;
 import static com.catcher.utils.JwtUtils.*;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RefreshTokenAdaptor implements AuthService {
@@ -50,7 +52,7 @@ public class RefreshTokenAdaptor implements AuthService {
             }
             dbManager.deleteKey(authentication.getName());
         } catch (BaseException e) {
-
+            log.warn("ErrorCode = {}, Message = {}", e.getStatus().getCode(), e.getStatus().getMessage());
         }
     }
 
@@ -62,15 +64,15 @@ public class RefreshTokenAdaptor implements AuthService {
             String key = generateBlackListToken(accessToken);
             dbManager.putValue(key, "", ACCESS_TOKEN_EXPIRATION_MILLIS);
         } catch (BaseException e) {
-
+            log.warn("ErrorCode = {}, Message = {}", e.getStatus().getCode(), e.getStatus().getMessage());
         }
     }
 
     private String getAccessToken(String accessToken) {
-       if (accessToken != null && accessToken.startsWith("Bearer ")) {
-            accessToken = accessToken.substring(7);
+        if (accessToken != null && accessToken.startsWith("Bearer ")) {
+            return accessToken.substring(7);
         }
-        return accessToken;
+        return null;
     }
 
     private String getRefreshToken(String name) {

--- a/src/main/java/com/catcher/resource/AuthController.java
+++ b/src/main/java/com/catcher/resource/AuthController.java
@@ -5,7 +5,6 @@ import com.catcher.core.dto.TokenDto;
 import com.catcher.core.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -13,7 +12,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.catcher.config.JwtTokenProvider.removeCookie;
 import static com.catcher.config.JwtTokenProvider.setRefreshCookie;
 import static com.catcher.utils.JwtUtils.REFRESH_TOKEN_NAME;
 
@@ -30,13 +28,5 @@ public class AuthController {
         TokenDto tokenDto = authService.reissueRefreshToken(refreshToken);
         setRefreshCookie(response, tokenDto.getRefreshToken());
         return CommonResponse.success(tokenDto.getAccessToken());
-    }
-
-    @Operation(summary = "토큰 폐기")
-    @PostMapping(value = "/discard")
-    public CommonResponse discard(@CookieValue(value = REFRESH_TOKEN_NAME, required = false) String refreshToken, HttpServletRequest request, HttpServletResponse response) {
-        authService.discardRefreshToken(refreshToken);
-        removeCookie(request, response);
-        return CommonResponse.success();
     }
 }

--- a/src/main/java/com/catcher/resource/UserController.java
+++ b/src/main/java/com/catcher/resource/UserController.java
@@ -6,17 +6,18 @@ import com.catcher.core.dto.user.UserCreateRequest;
 import com.catcher.core.dto.user.UserLoginRequest;
 import com.catcher.core.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.catcher.common.response.CommonResponse.success;
 import static com.catcher.config.JwtTokenProvider.setRefreshCookie;
+import static com.catcher.utils.HttpServletUtils.deleteCookie;
+import static com.catcher.utils.JwtUtils.REFRESH_TOKEN_NAME;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @RequiredArgsConstructor
 @RestController
@@ -39,5 +40,16 @@ public class UserController {
         TokenDto tokenDto = userService.login(userLoginReqDto);
         setRefreshCookie(response, tokenDto.getRefreshToken());
         return success(tokenDto.getAccessToken());
+    }
+
+    @Operation(summary = "로그아웃")
+    @DeleteMapping("/logout")
+    public CommonResponse<Void> logout(HttpServletRequest request,
+                                       HttpServletResponse response,
+                                       @RequestHeader(name = AUTHORIZATION, required = false) String accessToken,
+                                       @CookieValue(name = REFRESH_TOKEN_NAME, required = false) String refreshToken) {
+        userService.logout(accessToken, refreshToken);
+        deleteCookie(request, response, REFRESH_TOKEN_NAME);
+        return success();
     }
 }

--- a/src/main/java/com/catcher/security/JwtSecurityConfig.java
+++ b/src/main/java/com/catcher/security/JwtSecurityConfig.java
@@ -2,6 +2,7 @@ package com.catcher.security;
 
 import com.catcher.config.JwtFilter;
 import com.catcher.config.JwtTokenProvider;
+import com.catcher.core.database.DBManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -11,10 +12,11 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
     private final JwtTokenProvider jwtTokenProvider;
+    private final DBManager dbManager;
 
     @Override
     public void configure(HttpSecurity http) throws Exception {
-        JwtFilter customFilter = new JwtFilter(jwtTokenProvider);
+        JwtFilter customFilter = new JwtFilter(jwtTokenProvider, dbManager);
         http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
     }
 }

--- a/src/main/java/com/catcher/security/SecurityConfig.java
+++ b/src/main/java/com/catcher/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.catcher.common.GlobalExceptionHandlerFilter;
 import com.catcher.config.JwtAccessDeniedHandler;
 import com.catcher.config.JwtAuthenticationEntryPoint;
 import com.catcher.config.JwtTokenProvider;
+import com.catcher.core.database.DBManager;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -27,6 +28,7 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final DBManager dbManager;
     private final String[] allowedUrls = {
             "/", "/swagger-ui/**", "/users/**", "favicon.ico",
             "/health/**", "/auth/**", "/oauth/**", "/v3/api-docs/**"
@@ -64,7 +66,7 @@ public class SecurityConfig {
                                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 )
                 .addFilterBefore(new GlobalExceptionHandlerFilter(objectMapper), UsernamePasswordAuthenticationFilter.class)
-                .apply(new JwtSecurityConfig(jwtTokenProvider));
+                .apply(new JwtSecurityConfig(jwtTokenProvider, dbManager));
 
         return httpSecurity.build();
     }

--- a/src/main/java/com/catcher/utils/JwtUtils.java
+++ b/src/main/java/com/catcher/utils/JwtUtils.java
@@ -5,4 +5,9 @@ public class JwtUtils {
     public static long REFRESH_TOKEN_EXPIRATION_MILLIS = 1000L * 60 * 60 * 24 * 7; // 7Days
 
     public final static String REFRESH_TOKEN_NAME = "RefreshToken";
+    public final static String BLACK_LIST_TOKEN = "BlackListToken";
+
+    public final static String generateBlackListToken(String accessToken) {
+        return BLACK_LIST_TOKEN + "[" + accessToken + "]";
+    }
 }

--- a/src/test/java/com/catcher/config/JwtFilterTest.java
+++ b/src/test/java/com/catcher/config/JwtFilterTest.java
@@ -127,7 +127,7 @@ class JwtFilterTest {
         User user = registerStubUser();
         Authentication authentication = createAuthentication(user.getUsername(), user.getPassword());
         String accessToken = jwtTokenProvider.createAccessToken(authentication);
-        authService.discardAccessToken(accessToken);
+        authService.discardAccessToken("Bearer " + accessToken);
         //when
         Mockito.when(request.getHeader("Authorization")).thenReturn("Bearer " + accessToken);
         jwtFilter.doFilterInternal(request, response,filterChain);

--- a/src/test/java/com/catcher/config/JwtFilterTest.java
+++ b/src/test/java/com/catcher/config/JwtFilterTest.java
@@ -2,9 +2,12 @@ package com.catcher.config;
 
 import com.catcher.app.AppApplication;
 import com.catcher.common.exception.BaseException;
+import com.catcher.core.database.DBManager;
 import com.catcher.core.database.UserRepository;
 import com.catcher.core.domain.entity.User;
 import com.catcher.core.domain.entity.enums.UserRole;
+import com.catcher.core.service.AuthService;
+import com.catcher.core.service.UserService;
 import com.catcher.testconfiguriation.EmbeddedRedisConfiguration;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -45,12 +48,18 @@ class JwtFilterTest {
     EntityManager em;
     @Autowired
     JwtTokenProvider jwtTokenProvider;
+    @Autowired
+    DBManager dbManager;
+    @Autowired
+    UserService userService;
+    @Autowired
+    AuthService authService;
 
     JwtFilter jwtFilter;
 
     @BeforeEach
     void beforeEach() {
-        jwtFilter = new JwtFilter(jwtTokenProvider);
+        jwtFilter = new JwtFilter(jwtTokenProvider, dbManager);
     }
 
     @DisplayName("Access 토큰 없을 시 그냥 통과")
@@ -105,6 +114,26 @@ class JwtFilterTest {
         Authentication currentAuthentication = SecurityContextHolder.getContext().getAuthentication();
         assertThat(currentAuthentication).isNotNull();
         assertThat(currentAuthentication.getName()).isEqualTo(user.getUsername());
+    }
+
+    @DisplayName("로그아웃한 Access 토큰이면, Authentication이 설정이 되면 안된다.")
+    @Test
+    @Transactional
+    void invalid_logout_access_token_filter() throws ServletException, IOException {
+        //given
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        FilterChain filterChain = Mockito.mock(FilterChain.class);
+        User user = registerStubUser();
+        Authentication authentication = createAuthentication(user.getUsername(), user.getPassword());
+        String accessToken = jwtTokenProvider.createAccessToken(authentication);
+        authService.discardAccessToken(accessToken);
+        //when
+        Mockito.when(request.getHeader("Authorization")).thenReturn("Bearer " + accessToken);
+        jwtFilter.doFilterInternal(request, response,filterChain);
+        //then
+        Authentication currentAuthentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(currentAuthentication).isNull();
     }
 
     private Authentication createAuthentication(String username, String password) {

--- a/src/test/java/com/catcher/core/service/AuthServiceTest.java
+++ b/src/test/java/com/catcher/core/service/AuthServiceTest.java
@@ -87,7 +87,7 @@ class AuthServiceTest {
         UserCreateRequest userCreateRequest = userCreateRequest(createRandomUUID(), createRandomUUID(), createRandomUUID(), createRandomUUID());
         TokenDto tokenDto = userService.signUpUser(userCreateRequest);
         //when
-        authService.discardAccessToken(tokenDto.getAccessToken());
+        authService.discardAccessToken("Bearer " + tokenDto.getAccessToken());
         //then
         Optional<String> value = dbManager.getValue(generateBlackListToken(tokenDto.getAccessToken()));
         assertThat(value).isPresent();

--- a/src/test/java/com/catcher/core/service/AuthServiceTest.java
+++ b/src/test/java/com/catcher/core/service/AuthServiceTest.java
@@ -16,8 +16,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZonedDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
+import static com.catcher.utils.JwtUtils.generateBlackListToken;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -63,9 +65,9 @@ class AuthServiceTest {
                 .isInstanceOf(BaseException.class);
     }
 
-    @DisplayName("토큰 폐기 후, 재발급 시, 에러 반환")
+    @DisplayName("리프레쉬 토큰 폐기 후, 재발급 시, 에러 반환")
     @Test
-    void discard_token_then_reissue_token() {
+    void discard_refresh_token_then_reissue_token() {
         //given
         UserCreateRequest userCreateRequest = userCreateRequest(createRandomUUID(), createRandomUUID(), createRandomUUID(), createRandomUUID());
         TokenDto preTokenDto = userService.signUpUser(userCreateRequest);
@@ -76,6 +78,19 @@ class AuthServiceTest {
         //then
         assertThatThrownBy(() -> authService.reissueRefreshToken(preTokenDto.getRefreshToken()))
                 .isInstanceOf(BaseException.class);
+    }
+
+    @DisplayName("액세스 토큰 폐기 시, 저장소에 블랙리스트 토큰 저장")
+    @Test
+    void discard_access_token() {
+        //given
+        UserCreateRequest userCreateRequest = userCreateRequest(createRandomUUID(), createRandomUUID(), createRandomUUID(), createRandomUUID());
+        TokenDto tokenDto = userService.signUpUser(userCreateRequest);
+        //when
+        authService.discardAccessToken(tokenDto.getAccessToken());
+        //then
+        Optional<String> value = dbManager.getValue(generateBlackListToken(tokenDto.getAccessToken()));
+        assertThat(value).isPresent();
     }
 
     private UserCreateRequest userCreateRequest(String username, String email, String nickname, String phone) {

--- a/src/test/java/com/catcher/core/service/UserServiceTest.java
+++ b/src/test/java/com/catcher/core/service/UserServiceTest.java
@@ -277,7 +277,7 @@ class UserServiceTest {
         TokenDto tokenDto = userService.signUpUser(userCreateRequest);
         flushAndClearPersistence();
         //when
-        userService.logout(tokenDto.getAccessToken(), tokenDto.getRefreshToken());
+        userService.logout("Bearer " + tokenDto.getAccessToken(), tokenDto.getRefreshToken());
         //then
         Optional<String> value = dbManager.getValue(generateBlackListToken(tokenDto.getAccessToken()));
         assertThat(value).isPresent();

--- a/src/test/java/com/catcher/core/service/UserServiceTest.java
+++ b/src/test/java/com/catcher/core/service/UserServiceTest.java
@@ -2,6 +2,7 @@ package com.catcher.core.service;
 
 import com.catcher.app.AppApplication;
 import com.catcher.common.exception.BaseException;
+import com.catcher.core.database.DBManager;
 import com.catcher.core.database.UserRepository;
 import com.catcher.core.domain.entity.User;
 import com.catcher.core.domain.entity.enums.UserRole;
@@ -20,9 +21,11 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZonedDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 import static com.catcher.core.domain.entity.enums.UserProvider.*;
+import static com.catcher.utils.JwtUtils.generateBlackListToken;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -36,7 +39,8 @@ class UserServiceTest {
     UserService userService;
     @Autowired
     PasswordEncoder passwordEncoder;
-
+    @Autowired
+    DBManager dbManager;
     @PersistenceContext
     EntityManager em;
 
@@ -263,6 +267,20 @@ class UserServiceTest {
         User user = userRepository.findByEmail(userCreateRequest.getEmail()).orElseThrow();
         assertThat(user.getUserProvider()).isEqualTo(CATCHER);
         assertThat(user.getPhoneAuthentication()).isNotNull();
+    }
+
+    @DisplayName("정상 로그아웃 시, 블랙리스트 토큰에 저장되어야 한다.")
+    @Test
+    void valid_logout() {
+        //given
+        UserCreateRequest userCreateRequest = userCreateRequest(createRandomUUID(), createRandomUUID(), createRandomUUID(), createRandomUUID());
+        TokenDto tokenDto = userService.signUpUser(userCreateRequest);
+        flushAndClearPersistence();
+        //when
+        userService.logout(tokenDto.getAccessToken(), tokenDto.getRefreshToken());
+        //then
+        Optional<String> value = dbManager.getValue(generateBlackListToken(tokenDto.getAccessToken()));
+        assertThat(value).isPresent();
     }
 
     //region PRIVATE METHOD

--- a/src/test/java/com/catcher/resource/AuthControllerTest.java
+++ b/src/test/java/com/catcher/resource/AuthControllerTest.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
-import static com.catcher.common.BaseResponseStatus.SUCCESS;
 import static com.catcher.utils.JwtUtils.REFRESH_TOKEN_EXPIRATION_MILLIS;
 import static com.catcher.utils.JwtUtils.REFRESH_TOKEN_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -74,7 +73,7 @@ class AuthControllerTest {
         this.previousAccessToken = tokenDto.getAccessToken();
     }
 
-    @DisplayName("정상 리프레쉬 토큰으로 요청 시, 새로운 토큰 발행되어야 한다.")
+    @DisplayName("정상 리프레쉬 토큰으로 새로운 토큰 요청 시, 새로운 토큰 발행되어야 한다.")
     @Test
     void reissue_token() throws Exception {
         //given
@@ -96,47 +95,7 @@ class AuthControllerTest {
         assertThat(resultActions.andReturn().getResponse().getCookie(REFRESH_TOKEN_NAME).getValue()).isNotEqualTo(previousRefreshToken);
     }
 
-    @DisplayName("정상 리프레쉬 토큰으로 폐기 시, 정상 응답 및 토큰이 없어야 한다.")
-    @Test
-    void discard_token() throws Exception {
-        //given
-        Cookie cookie = generateCookie(REFRESH_TOKEN_NAME, previousRefreshToken);
-
-        //when
-        ResultActions resultActions = mockMvc.perform(post("/auth/discard")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(previousRefreshToken))
-                .cookie(cookie)
-        ).andExpect(status().isOk());
-        CommonResponse commonResponse = objectMapper.readValue(resultActions.andReturn().getResponse().getContentAsString(), CommonResponse.class);
-
-        //then
-        assertThat(commonResponse.isSuccess()).isTrue();
-        assertThat(commonResponse.getCode()).isEqualTo(SUCCESS.getCode());
-        assertThat(commonResponse.getResult()).isNull();
-        assertThat(resultActions.andReturn().getResponse().getCookie(REFRESH_TOKEN_NAME).getValue()).isEqualTo("");
-    }
-
-    @DisplayName("비정상 리프레쉬 토큰으로 폐기 시, 예외 응답")
-    @Test
-    void invalid_discard_token() throws Exception {
-        //given
-        Cookie cookie = generateCookie(REFRESH_TOKEN_NAME, previousRefreshToken + "1");
-
-        //when
-        MvcResult mvcResult = mockMvc.perform(post("/auth/discard")
-                .contentType(MediaType.APPLICATION_JSON)
-                .cookie(cookie)
-        ).andReturn();
-        CommonResponse commonResponse = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), CommonResponse.class);
-
-        //then
-        assertThat(commonResponse.isSuccess()).isFalse();
-        assertThat(commonResponse.getCode()).isEqualTo(BaseResponseStatus.INVALID_JWT.getCode());
-        assertThat(commonResponse.getResult()).isEqualTo(BaseResponseStatus.INVALID_JWT.getMessage());
-    }
-
-    @DisplayName("비정상 리프레쉬 토큰으로 폐기 시, 예외 응답")
+    @DisplayName("비정상 리프레쉬 토큰으로 새로운 토큰 요청시, 예외 응답")
     @Test
     void invalid_reissue_token() throws Exception {
         //given

--- a/src/test/java/com/catcher/resource/UserControllerTest.java
+++ b/src/test/java/com/catcher/resource/UserControllerTest.java
@@ -4,13 +4,13 @@ import com.catcher.app.AppApplication;
 import com.catcher.common.BaseResponseStatus;
 import com.catcher.common.CatcherControllerAdvice;
 import com.catcher.common.response.CommonResponse;
+import com.catcher.core.database.DBManager;
 import com.catcher.core.database.UserRepository;
 import com.catcher.core.domain.entity.User;
 import com.catcher.core.domain.entity.enums.UserRole;
 import com.catcher.core.dto.user.UserCreateRequest;
 import com.catcher.core.dto.user.UserLoginRequest;
 import com.catcher.testconfiguriation.EmbeddedRedisConfiguration;
-import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -19,8 +19,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -30,14 +30,16 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
 import static com.catcher.core.domain.entity.enums.UserProvider.CATCHER;
 import static com.catcher.utils.JwtUtils.REFRESH_TOKEN_NAME;
+import static com.catcher.utils.JwtUtils.generateBlackListToken;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ActiveProfiles("test")
 @SpringBootTest(classes = {AppApplication.class, EmbeddedRedisConfiguration.class})
@@ -49,12 +51,12 @@ class UserControllerTest {
     UserRepository userRepository;
     @Autowired
     PasswordEncoder passwordEncoder;
-
     @Autowired
     UserController userController;
-
     @Autowired
     ObjectMapper objectMapper;
+    @Autowired
+    DBManager dbManager;
 
     User user;
 
@@ -330,10 +332,38 @@ class UserControllerTest {
         assertThat(resultActions.andReturn().getResponse().getCookie(REFRESH_TOKEN_NAME)).isNotNull();
     }
 
-    private <T> T getResponseObject(MockHttpServletResponse response, Class<T> type) throws IOException {
-        JavaType javaType = objectMapper.getTypeFactory().constructParametricType(CommonResponse.class, type);
-        CommonResponse<T> result = objectMapper.readValue(response.getContentAsString(), javaType);
-        return result.getResult();
+    @DisplayName("정상 토큰으로 로그아웃 시, 블랙리스트 토큰 저장")
+    @Test
+    void valid_logout() throws Exception {
+        UserLoginRequest userLoginRequest = new UserLoginRequest(user.getUsername(), rawPassword);
+        //when
+        ResultActions resultActions = mockMvc.perform(post("/users/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userLoginRequest))
+        );
+        String accessToken = (String) objectMapper.readValue(resultActions.andReturn().getResponse().getContentAsString(), CommonResponse.class).getResult();
+        ResultActions logoutResult = mockMvc.perform(delete("/users/logout")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .content(objectMapper.writeValueAsString(userLoginRequest))
+        ).andExpect(status().isOk());
+        //then
+        assertThat(dbManager.getValue(generateBlackListToken(accessToken))).isPresent();
+    }
+    
+    @DisplayName("비정상 토큰으로 로그아웃 시, 200 정상 응답")
+    @Test
+    void invalid_logout() throws Exception {
+        UserLoginRequest userLoginRequest = new UserLoginRequest(user.getUsername(), rawPassword);
+        String invalidAccessToken = "gadsklgasg.fadsfklalsfjks.fadsklfsa";
+        //when
+        ResultActions logoutResult = mockMvc.perform(delete("/users/logout")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, invalidAccessToken)
+                .content(objectMapper.writeValueAsString(userLoginRequest))
+        ).andExpect(status().isOk());
+        //then
+        assertThat(dbManager.getValue(generateBlackListToken(invalidAccessToken))).isEmpty();
     }
 
     private UserCreateRequest userCreateRequest(String username, String nickname, String phone, String email) {

--- a/src/test/java/com/catcher/resource/UserControllerTest.java
+++ b/src/test/java/com/catcher/resource/UserControllerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -31,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.time.ZonedDateTime;
+import java.util.Set;
 import java.util.UUID;
 
 import static com.catcher.core.domain.entity.enums.UserProvider.CATCHER;
@@ -344,12 +346,15 @@ class UserControllerTest {
         String accessToken = (String) objectMapper.readValue(resultActions.andReturn().getResponse().getContentAsString(), CommonResponse.class).getResult();
         ResultActions logoutResult = mockMvc.perform(delete("/users/logout")
                 .contentType(MediaType.APPLICATION_JSON)
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                 .content(objectMapper.writeValueAsString(userLoginRequest))
         ).andExpect(status().isOk());
+        Set keys = redisTemplate.keys("*");
         //then
         assertThat(dbManager.getValue(generateBlackListToken(accessToken))).isPresent();
     }
+    @Autowired
+    RedisTemplate redisTemplate;
     
     @DisplayName("비정상 토큰으로 로그아웃 시, 200 정상 응답")
     @Test


### PR DESCRIPTION
로그아웃 기능 구현완료했습니다.

로그아웃 요청시, RefreshToken은 레디스에서 제거되며, AccessToken은 블랙리스트 토큰으로 레디스에 저장됩니다.
이에 따른 전반적인 기능 수정 되었습니다.

- 기존 토큰 폐기 엔드포인트가 사라졌습니다.
- Auth Service에 Access, Refresh Token  discard 기능 구현하였습니다.
- Jwt 필터에서 검증 시,  블랙리스트 토큰 인지 확인하는 작업이 추가 되었습니다.

