### PR TITLE
Feat: Key Generator 클래스 적용 & 

### DIFF
--- a/src/main/java/com/catcher/config/JwtFilter.java
+++ b/src/main/java/com/catcher/config/JwtFilter.java
@@ -2,7 +2,6 @@ package com.catcher.config;
 
 import com.catcher.common.exception.BaseException;
 import com.catcher.core.database.DBManager;
-import com.catcher.utils.JwtUtils;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,6 +16,8 @@ import java.io.IOException;
 
 import static com.catcher.common.BaseResponseStatus.REDIS_ERROR;
 import static com.catcher.utils.HttpServletUtils.getHeader;
+import static com.catcher.utils.KeyGenerator.AuthType.BLACK_LIST_ACCESS_TOKEN;
+import static com.catcher.utils.KeyGenerator.generateKey;
 import static org.apache.http.HttpHeaders.AUTHORIZATION;
 
 /**
@@ -51,8 +52,7 @@ public class JwtFilter extends OncePerRequestFilter {
     }
 
     private boolean isBlackList(String accessToken) {
-        String blackListToken = JwtUtils.generateBlackListToken(accessToken);
-        return dbManager.getValue(blackListToken).isPresent();
+        return dbManager.getValue(generateKey(accessToken, BLACK_LIST_ACCESS_TOKEN)).isPresent();
     }
 
     private String getAccessToken(HttpServletRequest request) {

--- a/src/main/java/com/catcher/core/port/KeyValueDataStorePort.java
+++ b/src/main/java/com/catcher/core/port/KeyValueDataStorePort.java
@@ -2,7 +2,7 @@ package com.catcher.core.port;
 
 public interface KeyValueDataStorePort {
 
-    void saveValidationCodeWithUserId(String key, String value);
+    void saveValidationCodeWithKey(String key, String value);
 
     String findValidationCodeWithKey(String key);
 

--- a/src/main/java/com/catcher/core/port/KeyValueDataStorePort.java
+++ b/src/main/java/com/catcher/core/port/KeyValueDataStorePort.java
@@ -2,8 +2,10 @@ package com.catcher.core.port;
 
 public interface KeyValueDataStorePort {
 
-    void saveValidationCodeWithUserId(String userId, String value);
+    void saveValidationCodeWithUserId(String key, String value);
 
     String findValidationCodeWithKey(String key);
+
+    void deleteKey(String key);
 
 }

--- a/src/main/java/com/catcher/core/service/AuthCodeService.java
+++ b/src/main/java/com/catcher/core/service/AuthCodeService.java
@@ -31,7 +31,7 @@ public class AuthCodeService {
         final var user = userRepository.findByEmail(email).orElseThrow(() -> new BaseException(BaseResponseStatus.USERS_NOT_EXISTS));
         final var generatedKey = String.valueOf(generateSixDigitsRandomCode());
         final var generatedDataStoreKey = generateKey(user.getId(), authType);
-        keyValueDataStorePort.saveValidationCodeWithUserId(generatedDataStoreKey, generatedKey);
+        keyValueDataStorePort.saveValidationCodeWithKey(generatedDataStoreKey, generatedKey);
 
         return generatedKey;
     }

--- a/src/main/java/com/catcher/core/service/CaptchaService.java
+++ b/src/main/java/com/catcher/core/service/CaptchaService.java
@@ -31,7 +31,7 @@ public class CaptchaService {
         Captcha captcha = generateCaptcha();
 
         final String generatedUserKey = generateKey(user.getId(), authType);
-        keyValueDataStorePort.saveValidationCodeWithUserId(generatedUserKey, captcha.getAnswer());
+        keyValueDataStorePort.saveValidationCodeWithKey(generatedUserKey, captcha.getAnswer());
 
         return captcha;
     }

--- a/src/main/java/com/catcher/core/service/CaptchaService.java
+++ b/src/main/java/com/catcher/core/service/CaptchaService.java
@@ -11,6 +11,9 @@ import org.springframework.stereotype.Service;
 import java.awt.image.BufferedImage;
 import java.util.Objects;
 
+import static com.catcher.utils.KeyGenerator.AuthType;
+import static com.catcher.utils.KeyGenerator.generateKey;
+
 @Service
 @RequiredArgsConstructor
 public class CaptchaService {
@@ -22,13 +25,12 @@ public class CaptchaService {
 
     private final KeyValueDataStorePort keyValueDataStorePort;
 
-    public Captcha generateCaptchaAndSaveAnswer(final String email) {
-
+    public Captcha generateCaptchaAndSaveAnswer(final String email, AuthType authType) {
         final var user = userRepository.findByEmail(email).orElseThrow(() -> new BaseException(BaseResponseStatus.USERS_NOT_EXISTS));
 
         Captcha captcha = generateCaptcha();
 
-        final String generatedUserKey = generateCaptchaUserKey(user.getId());
+        final String generatedUserKey = generateKey(user.getId(), authType);
         keyValueDataStorePort.saveValidationCodeWithUserId(generatedUserKey, captcha.getAnswer());
 
         return captcha;
@@ -47,17 +49,19 @@ public class CaptchaService {
         return captcha.getImage();
     }
 
-    public boolean validateCaptcha(String userEmail, String userAnswer) {
+    public boolean validateCaptcha(String userEmail, String userAnswer, AuthType authType) {
         final var user = userRepository.findByEmail(userEmail).orElseThrow(() -> new BaseException(BaseResponseStatus.USERS_NOT_EXISTS));
 
-        final String generatedUserKEy = generateCaptchaUserKey(user.getId());
-        final String answer = keyValueDataStorePort.findValidationCodeWithKey(generatedUserKEy);
+        final String generatedUserKey = generateKey(user.getId(), authType);
+        final String answer = keyValueDataStorePort.findValidationCodeWithKey(generatedUserKey);
 
-        return Objects.equals(answer, userAnswer);
-    }
+        boolean isSuccess = Objects.equals(answer, userAnswer);
 
-    private String generateCaptchaUserKey(final Long userId) {
-        return String.format("%s_%s", userId, "CAPTCHA");
+        if(isSuccess) {
+            keyValueDataStorePort.deleteKey(generatedUserKey);
+        }
+
+        return isSuccess;
     }
 
 }

--- a/src/main/java/com/catcher/core/service/OAuthService.java
+++ b/src/main/java/com/catcher/core/service/OAuthService.java
@@ -34,6 +34,8 @@ import java.util.function.Supplier;
 
 import static com.catcher.common.BaseResponseStatus.*;
 import static com.catcher.utils.JwtUtils.REFRESH_TOKEN_EXPIRATION_MILLIS;
+import static com.catcher.utils.KeyGenerator.AuthType.REFRESH_TOKEN;
+import static com.catcher.utils.KeyGenerator.generateKey;
 
 @Service
 @Slf4j
@@ -132,7 +134,7 @@ public class OAuthService {
             String accessToken = jwtTokenProvider.createAccessToken(authentication);
             String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
 
-            dbManager.putValue(username, refreshToken, REFRESH_TOKEN_EXPIRATION_MILLIS);
+            dbManager.putValue(generateKey(username, REFRESH_TOKEN), refreshToken, REFRESH_TOKEN_EXPIRATION_MILLIS);
 
             return new TokenDto(accessToken, refreshToken);
         } catch (BadCredentialsException e) {

--- a/src/main/java/com/catcher/core/service/UserService.java
+++ b/src/main/java/com/catcher/core/service/UserService.java
@@ -10,6 +10,7 @@ import com.catcher.core.dto.TokenDto;
 import com.catcher.core.dto.user.UserCreateRequest;
 import com.catcher.core.dto.user.UserLoginRequest;
 import com.catcher.security.CatcherUser;
+import com.catcher.utils.KeyGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -28,6 +29,7 @@ import static com.catcher.core.domain.entity.BaseTimeEntity.zoneId;
 import static com.catcher.core.domain.entity.enums.UserProvider.CATCHER;
 import static com.catcher.core.domain.entity.enums.UserRole.USER;
 import static com.catcher.utils.JwtUtils.REFRESH_TOKEN_EXPIRATION_MILLIS;
+import static com.catcher.utils.KeyGenerator.AuthType.*;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -76,7 +78,7 @@ public class UserService {
             String accessToken = jwtTokenProvider.createAccessToken(authentication);
             String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
 
-            dbManager.putValue(username, refreshToken, REFRESH_TOKEN_EXPIRATION_MILLIS);
+            dbManager.putValue(KeyGenerator.generateKey(username, REFRESH_TOKEN), refreshToken, REFRESH_TOKEN_EXPIRATION_MILLIS);
 
             return new TokenDto(accessToken, refreshToken);
         } catch (BadCredentialsException e) {

--- a/src/main/java/com/catcher/infrastructure/adaptor/KeyValueDataStoreAdapter.java
+++ b/src/main/java/com/catcher/infrastructure/adaptor/KeyValueDataStoreAdapter.java
@@ -16,7 +16,7 @@ public class KeyValueDataStoreAdapter implements KeyValueDataStorePort {
     private static final long THREE_MINUTES_AS_MILLISECONDS = 180000L;
 
     @Override
-    public void saveValidationCodeWithUserId(final String key, final String authCode) {
+    public void saveValidationCodeWithKey(final String key, final String authCode) {
         redisManager.putValue(key, authCode, THREE_MINUTES_AS_MILLISECONDS);
     }
 

--- a/src/main/java/com/catcher/infrastructure/adaptor/KeyValueDataStoreAdapter.java
+++ b/src/main/java/com/catcher/infrastructure/adaptor/KeyValueDataStoreAdapter.java
@@ -16,13 +16,18 @@ public class KeyValueDataStoreAdapter implements KeyValueDataStorePort {
     private static final long THREE_MINUTES_AS_MILLISECONDS = 180000L;
 
     @Override
-    public void saveValidationCodeWithUserId(final String userId, final String authCode) {
-        redisManager.putValue(userId, authCode, THREE_MINUTES_AS_MILLISECONDS);
+    public void saveValidationCodeWithUserId(final String key, final String authCode) {
+        redisManager.putValue(key, authCode, THREE_MINUTES_AS_MILLISECONDS);
     }
 
     @Override
     public String findValidationCodeWithKey(final String key) {
         return redisManager.getValue(key).orElseThrow(() -> new BaseException(BaseResponseStatus.AUTH_CODE_NOT_FOUND));
+    }
+
+    @Override
+    public void deleteKey(String key) {
+        redisManager.deleteKey(key);
     }
 
 }

--- a/src/main/java/com/catcher/resource/UserController.java
+++ b/src/main/java/com/catcher/resource/UserController.java
@@ -31,6 +31,7 @@ import static com.catcher.common.response.CommonResponse.success;
 import static com.catcher.config.JwtTokenProvider.setRefreshCookie;
 import static com.catcher.utils.HttpServletUtils.deleteCookie;
 import static com.catcher.utils.JwtUtils.REFRESH_TOKEN_NAME;
+import static com.catcher.utils.KeyGenerator.AuthType.FIND_ID;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @RequiredArgsConstructor
@@ -70,29 +71,28 @@ public class UserController {
         return success();
     }
 
-    // TODO: 제목 교체
-    @Operation(summary = "이메일 인증코드 발송")
+    @Operation(summary = "ID 찾기 이메일 인증코드 발송")
     @PostMapping("/create-authcode/email")
     public CommonResponse<Void> sendEmailWithAuthCode(final AuthCodeSendRequest authCodeSendRequest) {
-
-        final var key = authCodeService.generateAndSaveRandomKey(authCodeSendRequest.getEmail());
+        final var key = authCodeService.generateAndSaveRandomKey(authCodeSendRequest.getEmail(), FIND_ID);
         emailService.sendEmail(authCodeSendRequest.getEmail(), "title", key);
+
         return success();
     }
 
     // TODO: 응답 타입은 따로 생각해보기
-    @Operation(summary = "인증 코드가 맞는지 검증")
+    @Operation(summary = "ID 찾기 인증 코드가 맞는지 검증")
     @PostMapping("/check-authcode/email")
     public CommonResponse<AuthCodeVerifyResponse> verifyAuthCode(final AuthCodeVerifyRequest authCodeVerifyRequest) {
-        final boolean isVerified = authCodeService.verifyAuthCode(authCodeVerifyRequest.getEmail(), authCodeVerifyRequest.getAuthCode());
+        final boolean isVerified = authCodeService.verifyAuthCode(authCodeVerifyRequest.getEmail(), authCodeVerifyRequest.getAuthCode(), FIND_ID);
 
         return success(new AuthCodeVerifyResponse(isVerified));
     }
 
-    @Operation(summary = "캡챠 이미지 생성 및 정답 임시 저장")
+    @Operation(summary = "ID 찾기 캡챠 이미지 생성 및 정답 임시 저장")
     @PostMapping("/captcha/email")
     public void captchaGenerate(final CaptchaGenerateRequest captchaGenerateRequest, HttpServletResponse response) throws IOException {
-        Captcha captcha = captchaService.generateCaptchaAndSaveAnswer(captchaGenerateRequest.getEmail());
+        Captcha captcha = captchaService.generateCaptchaAndSaveAnswer(captchaGenerateRequest.getEmail(), FIND_ID);
 
         BufferedImage image = captchaService.getImage(captcha);
         response.setHeader("Cache-Control", "no-store");
@@ -101,10 +101,10 @@ public class UserController {
         ImageIO.write(image, "png", response.getOutputStream());
     }
 
-    @Operation(summary = "캡챠 이미지 정답 검증")
+    @Operation(summary = "ID 찾기 캡챠 이미지 정답 검증")
     @PostMapping("/captcha/validate/email")
     public CommonResponse<CaptchaValidateResponse> validateCaptcha(final CaptchaValidateRequest captchaValidateRequest) {
-        final boolean isValidated = captchaService.validateCaptcha(captchaValidateRequest.getEmail(), captchaValidateRequest.getUserAnswer());
+        final boolean isValidated = captchaService.validateCaptcha(captchaValidateRequest.getEmail(), captchaValidateRequest.getUserAnswer(), FIND_ID);
 
         return success(new CaptchaValidateResponse(isValidated));
 

--- a/src/main/java/com/catcher/utils/JwtUtils.java
+++ b/src/main/java/com/catcher/utils/JwtUtils.java
@@ -5,9 +5,5 @@ public class JwtUtils {
     public static long REFRESH_TOKEN_EXPIRATION_MILLIS = 1000L * 60 * 60 * 24 * 7; // 7Days
 
     public final static String REFRESH_TOKEN_NAME = "RefreshToken";
-    public final static String BLACK_LIST_TOKEN = "BlackListToken";
 
-    public final static String generateBlackListToken(String accessToken) {
-        return BLACK_LIST_TOKEN + "[" + accessToken + "]";
-    }
 }

--- a/src/main/java/com/catcher/utils/KeyGenerator.java
+++ b/src/main/java/com/catcher/utils/KeyGenerator.java
@@ -1,0 +1,23 @@
+package com.catcher.utils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class KeyGenerator {
+
+    public static String generateKey(Object obj, AuthType type) {
+        return String.format("%s:%s", type.name(), obj);
+    }
+
+    public enum AuthType {
+        BLACK_LIST_ACCESS_TOKEN,
+        REFRESH_TOKEN,
+        FIND_ID,
+        FIND_PASSWORD,
+        FIND_PASSWORD_SUCCESS,
+        CAPTCHA_ID,
+        CAPTCHA_PASSWORD,
+
+    }
+}

--- a/src/main/java/com/catcher/utils/KeyGenerator.java
+++ b/src/main/java/com/catcher/utils/KeyGenerator.java
@@ -18,6 +18,5 @@ public final class KeyGenerator {
         FIND_PASSWORD_SUCCESS,
         CAPTCHA_ID,
         CAPTCHA_PASSWORD,
-
     }
 }

--- a/src/test/java/com/catcher/core/service/AuthServiceTest.java
+++ b/src/test/java/com/catcher/core/service/AuthServiceTest.java
@@ -6,6 +6,7 @@ import com.catcher.core.database.DBManager;
 import com.catcher.core.dto.TokenDto;
 import com.catcher.core.dto.user.UserCreateRequest;
 import com.catcher.testconfiguriation.EmbeddedRedisConfiguration;
+import com.catcher.utils.KeyGenerator;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayName;
@@ -19,7 +20,7 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
-import static com.catcher.utils.JwtUtils.generateBlackListToken;
+import static com.catcher.utils.KeyGenerator.AuthType.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -89,7 +90,7 @@ class AuthServiceTest {
         //when
         authService.discardAccessToken("Bearer " + tokenDto.getAccessToken());
         //then
-        Optional<String> value = dbManager.getValue(generateBlackListToken(tokenDto.getAccessToken()));
+        Optional<String> value = dbManager.getValue(KeyGenerator.generateKey(tokenDto.getAccessToken(), BLACK_LIST_ACCESS_TOKEN));
         assertThat(value).isPresent();
     }
 

--- a/src/test/java/com/catcher/core/service/UserServiceTest.java
+++ b/src/test/java/com/catcher/core/service/UserServiceTest.java
@@ -10,6 +10,7 @@ import com.catcher.core.dto.TokenDto;
 import com.catcher.core.dto.user.UserCreateRequest;
 import com.catcher.core.dto.user.UserLoginRequest;
 import com.catcher.testconfiguriation.EmbeddedRedisConfiguration;
+import com.catcher.utils.KeyGenerator;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayName;
@@ -25,7 +26,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static com.catcher.core.domain.entity.enums.UserProvider.*;
-import static com.catcher.utils.JwtUtils.generateBlackListToken;
+import static com.catcher.utils.KeyGenerator.AuthType.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -279,7 +280,7 @@ class UserServiceTest {
         //when
         userService.logout("Bearer " + tokenDto.getAccessToken(), tokenDto.getRefreshToken());
         //then
-        Optional<String> value = dbManager.getValue(generateBlackListToken(tokenDto.getAccessToken()));
+        Optional<String> value = dbManager.getValue(KeyGenerator.generateKey(tokenDto.getAccessToken(), BLACK_LIST_ACCESS_TOKEN));
         assertThat(value).isPresent();
     }
 

--- a/src/test/java/com/catcher/resource/UserControllerTest.java
+++ b/src/test/java/com/catcher/resource/UserControllerTest.java
@@ -33,12 +33,11 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.time.ZonedDateTime;
-import java.util.Set;
 import java.util.UUID;
 
 import static com.catcher.core.domain.entity.enums.UserProvider.CATCHER;
 import static com.catcher.utils.JwtUtils.REFRESH_TOKEN_NAME;
-import static com.catcher.utils.KeyGenerator.AuthType.*;
+import static com.catcher.utils.KeyGenerator.AuthType.BLACK_LIST_ACCESS_TOKEN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -350,7 +349,7 @@ class UserControllerTest {
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                 .content(objectMapper.writeValueAsString(userLoginRequest))
         ).andExpect(status().isOk());
-        Set keys = redisTemplate.keys("*");
+
         //then
         assertThat(dbManager.getValue(KeyGenerator.generateKey(accessToken, BLACK_LIST_ACCESS_TOKEN))).isPresent();
     }

--- a/src/test/java/com/catcher/resource/UserControllerTest.java
+++ b/src/test/java/com/catcher/resource/UserControllerTest.java
@@ -11,6 +11,7 @@ import com.catcher.core.domain.entity.enums.UserRole;
 import com.catcher.core.dto.user.UserCreateRequest;
 import com.catcher.core.dto.user.UserLoginRequest;
 import com.catcher.testconfiguriation.EmbeddedRedisConfiguration;
+import com.catcher.utils.KeyGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -37,7 +38,7 @@ import java.util.UUID;
 
 import static com.catcher.core.domain.entity.enums.UserProvider.CATCHER;
 import static com.catcher.utils.JwtUtils.REFRESH_TOKEN_NAME;
-import static com.catcher.utils.JwtUtils.generateBlackListToken;
+import static com.catcher.utils.KeyGenerator.AuthType.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -351,7 +352,7 @@ class UserControllerTest {
         ).andExpect(status().isOk());
         Set keys = redisTemplate.keys("*");
         //then
-        assertThat(dbManager.getValue(generateBlackListToken(accessToken))).isPresent();
+        assertThat(dbManager.getValue(KeyGenerator.generateKey(accessToken, BLACK_LIST_ACCESS_TOKEN))).isPresent();
     }
     @Autowired
     RedisTemplate redisTemplate;
@@ -368,7 +369,7 @@ class UserControllerTest {
                 .content(objectMapper.writeValueAsString(userLoginRequest))
         ).andExpect(status().isOk());
         //then
-        assertThat(dbManager.getValue(generateBlackListToken(invalidAccessToken))).isEmpty();
+        assertThat(dbManager.getValue(KeyGenerator.generateKey(invalidAccessToken, BLACK_LIST_ACCESS_TOKEN))).isEmpty();
     }
 
     private UserCreateRequest userCreateRequest(String username, String nickname, String phone, String email) {


### PR DESCRIPTION
1. 레디스 키 일관성 처리를 위한 클래스를 생성하였습니다.

<img width="595" alt="image" src="https://github.com/Project-Catcher/core-service/assets/108642272/06fc9905-505e-4fbc-8ac9-643067860b32">

2. 인증 성공시, 해당 값 레디스에서 제거 작업 수행 했습니다.
<img width="555" alt="image" src="https://github.com/Project-Catcher/core-service/assets/108642272/a022ba69-b03c-44d6-b74a-f6f4208af8b9">

3. Auth Type Enum의 생성으로, 기존의 캡챠 및 이메일 인증을 ID찾기 전용으로 변경하였습니다.
<img width="1280" alt="image" src="https://github.com/Project-Catcher/core-service/assets/108642272/52a81030-211c-4f15-940f-b88002433e41">

### TODO (우선순위 순)
-  KeyGenerator를 Catcher-service에도 적용할 예정 (이 PR과 같이 머지되어야함)
- 비밀번호 찾기 관련 로직 추가 예정
- 아이디 찾기 및 비밀번호 찾기 시 적절한 응답 반영 예정 ( 아이디 찾기 성공시 -> 아이디 응답 / 비밀번호 찾기 성공시 -> 임시 코드 부여 후, 해당 코드를 바탕으로 비밀번호 재설정 예정)
- 아이디 찾기 및 비밀번호 찾기 동일 기능에대한 코드 리팩토링 진행 예정